### PR TITLE
Add `keywords` for discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,15 @@
   "repository": "https://github.com/rwjblue/release-it-lerna-changelog",
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
+  "keywords": [
+    "release",
+    "release-it",
+    "release-it-plugin",
+    "plugin",
+    "conventional",
+    "changelog",
+    "lerna"
+  ],
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
Feel free to adjust, but let's keep `release-it-plugin` for discoverability of release-it plugins.