### PR TITLE
Use `editor` if present on `$PATH`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,12 @@ doing the release to customize the changelog before continuing.
 There are a few valid values for `launchEditor`:
 
 * `false` - Disables the feature.
-* `true` - The `process.env.EDITOR` value will be used as the command, and the
-  temporary file for editing is added as a argument (i.e. `$EDITOR /some/tmp/file`).
+* `true` - If present the `process.env.EDITOR` value will be used as the
+  command to invoke, if `process.env.EDITOR` is not found `process.env.PATH`
+  will be searched for a command named `editor` (which is commonly used on
+  Debian / Ubuntu systems to point to the currently configured editor). The
+  temporary file for editing is added as an argument (i.e.
+  `$EDITOR /some/tmp/file`).
 * any string - This string will be used as if it were a command. In order to
   interpolate the temporary file path in the string, you can use `${file}` in
   your configuration.

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = class LernaChangelogGeneratorPlugin extends Plugin {
 
       if (!EDITOR) {
         let error = new Error(
-          `release-it-lerna-changelog configured to use $EDITOR but no $EDITOR was found`
+          `release-it-lerna-changelog configured to launch your editor but no editor was found (tried $EDITOR and searching $PATH for \`editor\`).`
         );
         this.log.error(error.message);
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { EOL } = require('os');
 const fs = require('fs');
+const which = require('which');
 const { Plugin } = require('release-it');
 const { format } = require('release-it/lib/util');
 const tmp = require('tmp');
@@ -78,6 +79,11 @@ module.exports = class LernaChangelogGeneratorPlugin extends Plugin {
 
     if (typeof this.options.launchEditor === 'boolean') {
       let EDITOR = process.env.EDITOR;
+
+      if (!EDITOR) {
+        EDITOR = which.sync('editor', { nothrow: true });
+      }
+
       if (!EDITOR) {
         let error = new Error(
           `release-it-lerna-changelog configured to use $EDITOR but no $EDITOR was found`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "execa": "^4.0.0",
     "lerna-changelog": "^1.0.1",
     "release-it": "^13.5.4",
-    "tmp": "^0.1.0"
+    "tmp": "^0.1.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "ava": "^3.7.1",

--- a/test.js
+++ b/test.js
@@ -252,6 +252,7 @@ test('throws if launchEditor is `true`, no $EDITOR present, and `editor` is not 
 
   try {
     delete process.env.EDITOR;
+    process.env.PATH = '';
 
     await runTasks(plugin);
   } catch (error) {
@@ -266,6 +267,7 @@ test('throws if launchEditor is `true`, no $EDITOR present, and `editor` is not 
     );
   } finally {
     resetEDITOR();
+    resetPATH();
   }
 });
 

--- a/test.js
+++ b/test.js
@@ -29,9 +29,10 @@ const fs = require('fs');
 fs.writeFileSync('${output}', \`args: \${process.argv.slice(2).join(' ')}\`, 'utf-8');
 `;
 
-  await fs.writeFileSync(editor, fakeCommand, { encoding: 'utf-8' });
+  fs.writeFileSync(editor, fakeCommand, { encoding: 'utf-8' });
+  fs.chmodSync(editor, 0o777);
 
-  return { editor: `${process.execPath} ${editor}`, output };
+  return { editor, output };
 }
 
 class TestPlugin extends Plugin {
@@ -200,7 +201,7 @@ test('does not launch the editor for dry-run', async (t) => {
   t.is(fs.readFileSync(output, 'utf-8'), ``);
 });
 
-test('detects default editor if launchEditor is `true`', async (t) => {
+test('detects default editor from $EDITOR if launchEditor is `true`', async (t) => {
   let infile = tmp.fileSync().name;
 
   let { editor, output } = await buildEditorCommand();
@@ -217,7 +218,7 @@ test('detects default editor if launchEditor is `true`', async (t) => {
   }
 });
 
-test('throws if launchEditor is `true` and no $EDITOR present', async (t) => {
+test('throws if launchEditor is `true`, no $EDITOR present, and `editor` is not found on $PATH', async (t) => {
   let infile = tmp.fileSync().name;
 
   let plugin = buildPlugin({ infile, launchEditor: true });

--- a/test.js
+++ b/test.js
@@ -262,7 +262,7 @@ test('throws if launchEditor is `true`, no $EDITOR present, and `editor` is not 
 
     t.is(
       error.message,
-      `release-it-lerna-changelog configured to use $EDITOR but no $EDITOR was found`
+      `release-it-lerna-changelog configured to launch your editor but no editor was found (tried $EDITOR and searching $PATH for \`editor\`).`
     );
   } finally {
     resetEDITOR();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,7 +3651,7 @@ which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
On Debian / Ubuntu based systems `editor` is often available on the `$PATH` pointing to the currently configured editor.

This updates the `launchEditor: true` value to use `$EDITOR` first then fall back to `editor` if it is present and available on `$PATH`.

Fixes #34 

/cc @jelhan