### PR TITLE
Ensure custom changelog is displayed initially on release-it@13.5.3+.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,18 @@ module.exports = class LernaChangelogGeneratorPlugin extends Plugin {
     return nextVersion;
   }
 
+  getLatestVersion() {
+    // leveraging getLatestVersion so that we can mutate the global contexts
+    // `changelog` _after_ the built in plugin has ran. IMHO, this kinda sucks,
+    // but has the timing semantics needed to work around the changes in
+    // release-it@13.5.3.
+    //
+    // Hopefully a better resolution can be found over in
+    // https://github.com/release-it/release-it/issues/647
+    let { changelog } = this.getContext();
+    this.config.setContext({ changelog });
+  }
+
   getTagNameFromVersion(version) {
     let tagName = this.config.getContext('git.tagName');
 


### PR DESCRIPTION
This works around the issue described in https://github.com/release-it/release-it/issues/647 by leveraging `plugin.getLatestVersion` hook to override the global config's `changelog` value.

This sort of race is unfortunate, and we really should determine a better way to provide our functionality that is not brittle to changes in release-it.