### PR TITLE
Ensure `CHANGELOG.md` has correct version when `git.tagName` is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ module.exports = class LernaChangelogGeneratorPlugin extends Plugin {
 
   get nextVersion() {
     let { version } = this.config.getContext();
-    let nextVersion = this.getTagNameFromVersion(version);
+
+    let tagName = this.config.getContext('git.tagName');
+    let nextVersion = tagName ? format(tagName, { version }) : version;
 
     return nextVersion;
   }
@@ -31,12 +33,6 @@ module.exports = class LernaChangelogGeneratorPlugin extends Plugin {
   // this hook is supported by release-it@13.5.5+
   getChangelog() {
     return this.changelog;
-  }
-
-  getTagNameFromVersion(version) {
-    let tagName = this.config.getContext('git.tagName');
-
-    return format(tagName, { version });
   }
 
   async getTagForHEAD() {

--- a/test.js
+++ b/test.js
@@ -95,7 +95,8 @@ test('it invokes lerna-changelog', async (t) => {
 });
 
 test('it honors custom git.tagName formatting', async (t) => {
-  let plugin = buildPlugin();
+  let infile = tmp.fileSync().name;
+  let plugin = buildPlugin({ infile });
 
   plugin.config.setContext({ git: { tagName: 'v${version}' } });
 
@@ -105,6 +106,9 @@ test('it honors custom git.tagName formatting', async (t) => {
     ['git describe --tags --abbrev=0', { write: false }],
     [`${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`, { write: false }],
   ]);
+
+  const changelog = fs.readFileSync(infile, { encoding: 'utf8' });
+  t.is(changelog, `### v1.0.1 (2020-03-18)\n\nThe changelog\n\n`);
 });
 
 test('it sets the changelog without version information onto the config', async (t) => {


### PR DESCRIPTION
Previously we would call `format(null, { version })` which returns `''`.