### PR TITLE
Drop Node 11 and 13 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sinon": "^9.1.0"
   },
   "engines": {
-    "node": ">= 10"
+    "node": "10.* || 12.* || >= 14"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Both of these Node versions have been EOL'ed.
