### PR TITLE
fix: include CJS wrapper in published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "Robert Jackson <me@rwjblue.com>",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "cjs-wrapper.cjs"
   ],
   "scripts": {
     "lint:js": "eslint .",


### PR DESCRIPTION
The `4.0.0` release has an issue where `require` will attempt to import a file that isn't actually published to npm.

This change should resolve the problem.

Should fix #161 