### PR TITLE
Support release-it@15 in testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        release-it-version: ["14.0.0", "14.1.0", "14.2.0"]
+        release-it-version: ["14.0.0", "14.1.0", "14.2.0", "15.0.0", "15.1.1"]
 
     steps:
     - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
Adds `release-it@15` variants to the testing matrix.

Relates to https://github.com/rwjblue/release-it-yarn-workspaces/pull/73