### PR TITLE
Fix double-logged no-editor error and improve message (#57, #58)

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,12 +111,10 @@ export default class LernaChangelogGeneratorPlugin extends Plugin {
       }
 
       if (!EDITOR) {
-        let error = new Error(
-          `@release-it-plugins/lerna-changelog configured to launch your editor but no editor was found (tried $EDITOR and searching $PATH for \`editor\`).`
+        throw new Error(
+          `@release-it-plugins/lerna-changelog is configured to launch your editor but no editor was found. ` +
+            `Set the EDITOR environment variable, or set launchEditor to an explicit command (e.g. launchEditor: 'code --wait \${file}').`
         );
-        this.log.error(error.message);
-
-        throw error;
       }
 
       // `${file}` is interpolated just below

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -311,27 +311,36 @@ describe('@release-it-plugins/lerna-changelog', () => {
 
     let plugin = await buildPlugin({ infile, launchEditor: true });
 
+    let caughtError;
     try {
       delete process.env.EDITOR;
       process.env.PATH = '';
 
       await runTasks(plugin);
     } catch (error) {
-      expect(plugin.commands).toStrictEqual([
-        ['git describe --tags --abbrev=0', { write: false }],
-        [
-          `${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`,
-          { write: false },
-        ],
-      ]);
-
-      expect(error.message).toEqual(
-        `@release-it-plugins/lerna-changelog configured to launch your editor but no editor was found (tried $EDITOR and searching $PATH for \`editor\`).`
-      );
+      caughtError = error;
     } finally {
       resetEDITOR();
       resetPATH();
     }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError.message).toEqual(
+      `@release-it-plugins/lerna-changelog is configured to launch your editor but no editor was found. ` +
+        `Set the EDITOR environment variable, or set launchEditor to an explicit command (e.g. launchEditor: 'code --wait \${file}').`
+    );
+
+    // the plugin must not log the error itself — release-it logs thrown errors at the top level,
+    // so calling log.error here would cause the message to appear twice (fixes #58)
+    expect(plugin.log.error.mock.calls.length).toBe(0);
+
+    expect(plugin.commands).toStrictEqual([
+      ['git describe --tags --abbrev=0', { write: false }],
+      [
+        `${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`,
+        { write: false },
+      ],
+    ]);
   });
 
   test('launches configured editor, updates infile, and propogates changes to context', async () => {

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -330,9 +330,12 @@ describe('@release-it-plugins/lerna-changelog', () => {
         `Set the EDITOR environment variable, or set launchEditor to an explicit command (e.g. launchEditor: 'code --wait \${file}').`
     );
 
-    // the plugin must not log the error itself — release-it logs thrown errors at the top level,
-    // so calling log.error here would cause the message to appear twice (fixes #58)
-    expect(plugin.log.error.mock.calls.length).toBe(0);
+    // the plugin must not log the error itself — release-it logs thrown errors at the
+    // top level, so logging here too would make the message appear twice (fixes #58).
+    // release-it's test util mocks `log.error` with vitest (.mock.calls) on newer
+    // versions and sinon (.callCount) on older ones, so read whichever is present.
+    let errorLogCount = plugin.log.error.mock?.calls.length ?? plugin.log.error.callCount;
+    expect(errorLogCount).toBe(0);
 
     expect(plugin.commands).toStrictEqual([
       ['git describe --tags --abbrev=0', { write: false }],


### PR DESCRIPTION
## Summary
Fixes the "No editor" error handling in `_launchEditor`:

- **#58 (error displayed twice):** the plugin called `this.log.error(error.message)` *and* then threw the same error. release-it's top-level handler also logs thrown plugin errors, so the message appeared twice. This removes the redundant `log.error()` and throws directly.
- **#57 (unclear message):** the message is now actionable — it tells the user to set `$EDITOR` or configure `launchEditor` with an explicit command.

## Test plan
- Updated the existing "throws if launchEditor is true and no editor found" test to assert the error surfaces **exactly once** (`log.error` not called by the plugin) and matches the new message.
- `npm test` → 15 passing, lint clean.

Closes #57, closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)