### PR TITLE
Add opt-in `prettier` option to format generated changelog (#326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,31 @@ There are a few valid values for `launchEditor`:
 
 Each release will run `lerna-changelog` and prepend the results into `CHANGELOG.md`.
 
+### `prettier`
+
+When set to `true`, the generated changelog section is run through
+[Prettier](https://prettier.io/) as a Markdown formatter before being written
+to `infile` or shown in the editor. This ensures the output is consistently
+formatted and passes Prettier-based linters without requiring a separate
+post-release formatting step.
+
+```json
+{
+  "release-it": {
+    "plugins": {
+      "@release-it-plugins/lerna-changelog": {
+        "infile": "CHANGELOG.md",
+        "prettier": true
+      }
+    }
+  }
+}
+```
+
+This option is `false` by default so existing projects are unaffected. Prettier
+is an optional `peerDependency` — install it in your project (`npm install
+--save-dev prettier`) when enabling this option.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/index.js
+++ b/index.js
@@ -90,6 +90,12 @@ export default class LernaChangelogGeneratorPlugin extends Plugin {
       ? this.changelog.replace(UNRELEASED, this.nextVersion)
       : `## ${this.nextVersion} (${getToday()})`;
 
+    if (this.options.prettier) {
+      // prettier is an optional peerDependency; only loaded when this option is enabled
+      const prettier = await import('prettier');
+      changelog = await prettier.format(changelog, { parser: 'markdown' });
+    }
+
     let finalChangelog = await this.reviewChangelog(changelog);
 
     return finalChangelog;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "vitest": "^4.1.9"
   },
   "peerDependencies": {
+    "prettier": "^3.0.0",
     "release-it": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"
   },
   "engines": {
@@ -77,6 +78,11 @@
     },
     "github": {
       "release": true
+    }
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
     }
   }
 }

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -346,6 +346,35 @@ describe('@release-it-plugins/lerna-changelog', () => {
     ]);
   });
 
+  test('formats changelog with prettier when prettier option is true', async () => {
+    let infile = tmp.fileSync().name;
+    let plugin = await buildPlugin({ infile, prettier: true });
+    plugin.config.setContext({ git: { tagName: 'v${version}' } });
+
+    // use * list markers which prettier normalizes to -
+    plugin.responses[`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`] =
+      '## Unreleased (2020-03-18)\n\n* item one\n* item two';
+
+    await runTasks(plugin);
+
+    const changelog = fs.readFileSync(infile, { encoding: 'utf8' });
+    expect(changelog).toContain('- item one\n- item two');
+  });
+
+  test('does not format changelog when prettier option is not set', async () => {
+    let infile = tmp.fileSync().name;
+    let plugin = await buildPlugin({ infile });
+    plugin.config.setContext({ git: { tagName: 'v${version}' } });
+
+    plugin.responses[`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`] =
+      '## Unreleased (2020-03-18)\n\n* item one\n* item two';
+
+    await runTasks(plugin);
+
+    const changelog = fs.readFileSync(infile, { encoding: 'utf8' });
+    expect(changelog).toContain('* item one\n* item two');
+  });
+
   test('launches configured editor, updates infile, and propogates changes to context', async () => {
     let fakeEditorFile = tmp.fileSync().name;
     // using a function here so it is easier to author (vs a giant string interpolation)


### PR DESCRIPTION
## Summary
Adds an opt-in `prettier` plugin option (#326). When `prettier: true`, the generated changelog section is run through Prettier (markdown parser) in `processChangelog()` before it is written to `infile` or shown in the editor. Only the newly generated section is formatted — the existing `CHANGELOG.md` content is untouched.

### Design choices
- **Opt-in, default `false`** — formatting changes output for everyone, so existing projects are unaffected unless they enable it.
- **Prettier is an optional `peerDependency`, lazily loaded** via `await import('prettier')`. Consumers who don't enable the option never need Prettier installed. (`peerDependenciesMeta.prettier.optional = true`.)

## Test plan
- New tests: changelog with `*` list markers is normalized to `-` when `prettier: true`, and left untouched when the option is absent.
- `npm test` → 17 passing, lint clean.
- README documents the new option.

Closes #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)