### PR TITLE
Internalize lerna-changelog to drop the abandoned dependency

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -1,0 +1,357 @@
+// Internal reimplementation of the slice of `lerna-changelog` we relied on:
+// list commits in a range, resolve each to its GitHub PR, group by label, and
+// render markdown identical to what the old CLI produced. Monorepo
+// (`packages/*`) grouping and `lerna.json` support are intentionally dropped.
+import fs from 'fs';
+import path from 'path';
+import { execa } from 'execa';
+import hostedGitInfo from 'hosted-git-info';
+import pMap from 'p-map';
+
+const UNRELEASED_TAG = '___unreleased___';
+const COMMIT_FIX_REGEX = /(fix|close|resolve)(e?s|e?d)? [T#](\d+)/i;
+
+const DEFAULT_LABELS = {
+  breaking: ':boom: Breaking Change',
+  enhancement: ':rocket: Enhancement',
+  bug: ':bug: Bug Fix',
+  documentation: ':memo: Documentation',
+  internal: ':house: Internal',
+};
+
+const DEFAULT_IGNORE_COMMITTERS = [
+  'dependabot-bot',
+  'dependabot[bot]',
+  'dependabot-preview[bot]',
+  'greenkeeperio-bot',
+  'greenkeeper[bot]',
+  'renovate-bot',
+  'renovate[bot]',
+];
+
+export function findPullRequestId(message) {
+  const firstLine = message.split('\n')[0];
+
+  const merge = firstLine.match(/^Merge pull request #(\d+) from /);
+  if (merge) return merge[1];
+
+  const squash = firstLine.match(/\(#(\d+)\)$/);
+  if (squash) return squash[1];
+
+  const homu = firstLine.match(/^Auto merge of #(\d+) - /);
+  if (homu) return homu[1];
+
+  return null;
+}
+
+function parseLogMessage(commit) {
+  const parts = commit.match(/hash<(.+)> ref<(.*)> message<(.*)> date<(.*)>/) || [];
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return { sha: parts[1], refName: parts[2], summary: parts[3], date: parts[4] };
+}
+
+async function listCommits(from, to) {
+  const { stdout } = await execa('git', [
+    'log',
+    '--oneline',
+    '--pretty=hash<%h> ref<%D> message<%s> date<%cd>',
+    '--date=short',
+    `${from}..${to || ''}`,
+  ]);
+
+  return stdout.split('\n').filter(Boolean).map(parseLogMessage).filter(Boolean);
+}
+
+async function getRootPath() {
+  const { stdout } = await execa('git', ['rev-parse', '--show-toplevel']);
+  return stdout;
+}
+
+function readJSON(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, { encoding: 'utf8' }));
+  } catch {
+    return undefined;
+  }
+}
+
+function findRepoFromPkg(pkg) {
+  const url = pkg?.repository?.url || pkg?.repository;
+  if (!url) return undefined;
+
+  const info = hostedGitInfo.fromUrl(url);
+  if (info && info.type === 'github') {
+    return `${info.user}/${info.project}`;
+  }
+}
+
+function loadConfig(rootPath) {
+  const pkg = readJSON(path.join(rootPath, 'package.json')) || {};
+  const lerna = readJSON(path.join(rootPath, 'lerna.json')) || {};
+  const config = pkg.changelog || lerna.changelog || {};
+
+  const repo = config.repo || findRepoFromPkg(pkg);
+  if (!repo) {
+    throw new Error('Could not infer "repo" from the "package.json" file.');
+  }
+
+  return {
+    repo,
+    labels: config.labels || DEFAULT_LABELS,
+    ignoreCommitters: config.ignoreCommitters || DEFAULT_IGNORE_COMMITTERS,
+  };
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// How long to wait before retrying a rate-limited GitHub response. Secondary
+// rate limits send `Retry-After` (usually a few seconds); otherwise back off
+// exponentially, capped so a release never stalls for long.
+function retryDelayMs(res, attempt) {
+  const retryAfter = Number(res.headers.get('retry-after'));
+  if (retryAfter > 0) return retryAfter * 1000;
+  return Math.min(1000 * 2 ** attempt, 8000);
+}
+
+// `fetchImpl` and `sleepImpl` are injectable for tests.
+export async function fetchWithRetry(url, init, options = {}) {
+  // global fetch is stable on all supported Node versions (>=20.19); the lint
+  // rule keys off the engines floor and flags it conservatively.
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  const { attempts = 4, fetchImpl = fetch, sleepImpl = sleep } = options;
+
+  let res;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const isLast = attempt === attempts - 1;
+
+    try {
+      res = await fetchImpl(url, init);
+    } catch (err) {
+      if (isLast) throw err;
+      await sleepImpl(retryDelayMs({ headers: { get: () => null } }, attempt));
+      continue;
+    }
+
+    // 403/429 from GitHub are rate limiting; retry until attempts run out, then
+    // fall through and let the caller surface the error.
+    if ((res.status === 403 || res.status === 429) && !isLast) {
+      await sleepImpl(retryDelayMs(res, attempt));
+      continue;
+    }
+
+    return res;
+  }
+
+  return res;
+}
+
+function makeGithubRequest() {
+  const auth = process.env.GITHUB_AUTH;
+  if (!auth) {
+    throw new Error('Must provide GITHUB_AUTH');
+  }
+
+  return async (url) => {
+    const res = await fetchWithRetry(url, {
+      headers: {
+        Authorization: `token ${auth}`,
+        // GitHub rejects requests without a User-Agent; make-fetch-happen used
+        // to set one for us, native fetch does not.
+        'User-Agent': '@release-it-plugins/lerna-changelog',
+        Accept: 'application/vnd.github+json',
+      },
+    });
+
+    if (!res.ok) {
+      // tolerate non-JSON error bodies (e.g. an HTML 502 page)
+      const body = await res.json().catch(() => undefined);
+      throw new Error(
+        `GitHub fetch error: ${res.status} ${res.statusText}.\n${JSON.stringify(body)}`
+      );
+    }
+
+    return res.json();
+  };
+}
+
+function getToday() {
+  const date = new Date().toISOString();
+  return date.slice(0, date.indexOf('T'));
+}
+
+function toCommitInfos(commits) {
+  return commits.map((commit) => {
+    const { sha, refName, summary: message, date } = commit;
+
+    let tags;
+    if (refName.length > 1) {
+      const TAG_PREFIX = 'tag: ';
+      tags = refName
+        .split(', ')
+        .filter((ref) => ref.startsWith(TAG_PREFIX))
+        .map((ref) => ref.slice(TAG_PREFIX.length));
+    }
+
+    return { commitSHA: sha, message, tags, issueNumber: findPullRequestId(message), date };
+  });
+}
+
+function fillInCategories(commits, labels) {
+  for (const commit of commits) {
+    if (!commit.githubIssue || !commit.githubIssue.labels) continue;
+
+    const issueLabels = commit.githubIssue.labels.map((label) => label.name.toLowerCase());
+    commit.categories = Object.keys(labels)
+      .filter((label) => issueLabels.indexOf(label.toLowerCase()) !== -1)
+      .map((label) => labels[label]);
+  }
+}
+
+function groupByRelease(commits) {
+  const releaseMap = {};
+  let currentTags = [UNRELEASED_TAG];
+
+  for (const commit of commits) {
+    if (commit.tags && commit.tags.length > 0) {
+      currentTags = commit.tags;
+    }
+
+    for (const currentTag of currentTags) {
+      if (!releaseMap[currentTag]) {
+        const date = currentTag === UNRELEASED_TAG ? getToday() : commit.date;
+        releaseMap[currentTag] = { name: currentTag, date, commits: [] };
+      }
+      releaseMap[currentTag].commits.push(commit);
+    }
+  }
+
+  return Object.keys(releaseMap).map((tag) => releaseMap[tag]);
+}
+
+function ignoreCommitter(login, ignoreCommitters) {
+  return ignoreCommitters.some((c) => c === login || login.indexOf(c) > -1);
+}
+
+async function getCommitters(commits, request, ignoreCommitters) {
+  const committers = {};
+
+  for (const commit of commits) {
+    const issue = commit.githubIssue;
+    const login = issue && issue.user && issue.user.login;
+    if (login && !ignoreCommitter(login, ignoreCommitters) && !committers[login]) {
+      committers[login] = await request(`https://api.github.com/users/${login}`);
+    }
+  }
+
+  return Object.keys(committers).map((k) => committers[k]);
+}
+
+function renderContribution(commit, baseIssueUrl) {
+  const issue = commit.githubIssue;
+  if (!issue) return undefined;
+
+  let markdown = '';
+
+  if (issue.number && issue.pull_request && issue.pull_request.html_url) {
+    markdown += `[#${issue.number}](${issue.pull_request.html_url}) `;
+  }
+
+  let title = issue.title;
+  if (title && title.match(COMMIT_FIX_REGEX)) {
+    title = title.replace(COMMIT_FIX_REGEX, `Closes [#$3](${baseIssueUrl}$3)`);
+  }
+
+  markdown += `${title} ([@${issue.user.login}](${issue.user.html_url}))`;
+  return markdown;
+}
+
+function renderContributionList(commits, baseIssueUrl, prefix = '') {
+  return commits
+    .map((commit) => renderContribution(commit, baseIssueUrl))
+    .filter(Boolean)
+    .map((rendered) => `${prefix}* ${rendered}`)
+    .join('\n');
+}
+
+function renderContributor(contributor) {
+  const link = `[@${contributor.login}](${contributor.html_url})`;
+  return contributor.name ? `${contributor.name} (${link})` : link;
+}
+
+function renderContributorList(contributors) {
+  const rendered = contributors.map((c) => `- ${renderContributor(c)}`).sort();
+  return `#### Committers: ${contributors.length}\n${rendered.join('\n')}`;
+}
+
+function renderRelease(release, { categories, baseIssueUrl, unreleasedName }) {
+  const grouped = categories
+    .map((name) => ({
+      name,
+      commits: release.commits.filter((c) => c.categories && c.categories.indexOf(name) !== -1),
+    }))
+    .filter((category) => category.commits.length > 0);
+
+  if (grouped.length === 0) return '';
+
+  const releaseTitle = release.name === UNRELEASED_TAG ? unreleasedName : release.name;
+  let markdown = `## ${releaseTitle} (${release.date})`;
+
+  for (const category of grouped) {
+    markdown += `\n\n#### ${category.name}\n`;
+    markdown += renderContributionList(category.commits, baseIssueUrl);
+  }
+
+  if (release.contributors?.length) {
+    markdown += `\n\n${renderContributorList(release.contributors)}`;
+  }
+
+  return markdown;
+}
+
+export function renderMarkdown(releases, options) {
+  return releases
+    .map((release) => renderRelease(release, options))
+    .filter(Boolean)
+    .join('\n\n\n');
+}
+
+export default async function generateChangelog(options = {}) {
+  const { from, to = 'HEAD', nextVersion = 'Unreleased' } = options;
+  const rootPath = options.rootPath || (await getRootPath());
+  const { repo, labels, ignoreCommitters } = loadConfig(rootPath);
+
+  // `request` and `_rawCommits` are injected by tests; in real use `request`
+  // reads GITHUB_AUTH and throws up front if it is missing (matching
+  // lerna-changelog's behavior).
+  const request = options.request || makeGithubRequest();
+
+  const commits = toCommitInfos(options._rawCommits || (await listCommits(from, to)));
+
+  await pMap(
+    commits,
+    async (commit) => {
+      if (commit.issueNumber) {
+        commit.githubIssue = await request(
+          `https://api.github.com/repos/${repo}/issues/${commit.issueNumber}`
+        );
+      }
+    },
+    { concurrency: 5 }
+  );
+
+  fillInCategories(commits, labels);
+
+  const releases = groupByRelease(commits);
+  for (const release of releases) {
+    release.contributors = await getCommitters(release.commits, request, ignoreCommitters);
+  }
+
+  return renderMarkdown(releases, {
+    categories: Object.keys(labels).map((key) => labels[key]),
+    baseIssueUrl: `https://github.com/${repo}/issues/`,
+    unreleasedName: nextVersion,
+  });
+}

--- a/changelog.js
+++ b/changelog.js
@@ -1,7 +1,11 @@
-// Internal reimplementation of the slice of `lerna-changelog` we relied on:
-// list commits in a range, resolve each to its GitHub PR, group by label, and
-// render markdown identical to what the old CLI produced. Monorepo
-// (`packages/*`) grouping and `lerna.json` support are intentionally dropped.
+// Adapted from lerna-changelog (https://github.com/lerna/lerna-changelog),
+// Copyright (c) 2016-2018 Bo Borgerson and contributors, MIT License.
+//
+// This internalizes the slice of lerna-changelog we relied on: list commits
+// in a range, resolve each to its GitHub PR, group by label, and render
+// markdown identical to what the old CLI produced, using native fetch instead
+// of make-fetch-happen. Monorepo (`packages/*`) grouping and `lerna.json`
+// support are intentionally dropped.
 import fs from 'fs';
 import path from 'path';
 import { execa } from 'execa';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-import { createRequire } from 'module';
 import { EOL } from 'os';
 import fs from 'fs';
 import which from 'which';
@@ -9,6 +8,7 @@ import _ from 'lodash';
 import tmp from 'tmp';
 import { execaCommand } from 'execa';
 import { fromMarkdown } from 'mdast-util-from-markdown';
+import generateChangelog from './changelog.js';
 
 const template = _.template;
 const __filename = fileURLToPath(import.meta.url);
@@ -16,9 +16,6 @@ const __dirname = dirname(__filename);
 
 import validatePeerDependencies from 'validate-peer-dependencies';
 validatePeerDependencies(__dirname);
-
-const require = createRequire(import.meta.url);
-const LERNA_PATH = require.resolve('lerna-changelog/bin/cli');
 
 // using a const here, because we may need to change this value in the future
 // and this makes it much simpler
@@ -33,7 +30,7 @@ function getToday() {
 export default class LernaChangelogGeneratorPlugin extends Plugin {
   async init() {
     let from = (await this.getTagForHEAD()) || (await this.getFirstCommit());
-    this.changelog = await this._execLernaChangelog(from);
+    this.changelog = await this._generateChangelog(from);
 
     // this supports release-it < 13.5.3
     this.setContext({ changelog: this.changelog });
@@ -73,15 +70,8 @@ export default class LernaChangelogGeneratorPlugin extends Plugin {
     return this._firstCommit;
   }
 
-  async _execLernaChangelog(from) {
-    let changelog = await this.exec(
-      `${process.execPath} ${LERNA_PATH} --next-version=${UNRELEASED} --from=${from}`,
-      {
-        options: { write: false },
-      }
-    );
-
-    return changelog;
+  async _generateChangelog(from) {
+    return generateChangelog({ from, nextVersion: UNRELEASED });
   }
 
   async processChangelog() {
@@ -165,7 +155,7 @@ export default class LernaChangelogGeneratorPlugin extends Plugin {
       let firstCommit = await this.getFirstCommit();
 
       if (firstCommit) {
-        changelog = await this._execLernaChangelog(firstCommit, this.nextVersion);
+        changelog = await this._generateChangelog(firstCommit);
         changelog = changelog.replace(UNRELEASED, this.nextVersion);
 
         this.debug({ changelog });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "execa": "^9.6.1",
-        "lerna-changelog": "^2.2.0",
+        "hosted-git-info": "^9.0.3",
         "lodash": "^4.18.1",
         "mdast-util-from-markdown": "^2.0.3",
+        "p-map": "^7.0.4",
         "tmp": "^0.2.7",
         "validate-peer-dependencies": "^2.2.0",
         "which": "^6.0.1"
@@ -243,12 +244,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
-    },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -701,42 +696,6 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -1273,15 +1232,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1505,43 +1455,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1558,36 +1471,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -1701,6 +1584,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
@@ -1724,6 +1608,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1773,50 +1658,6 @@
         "magicast": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cacache/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {
@@ -1879,22 +1720,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -1928,15 +1753,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -1963,15 +1779,6 @@
         "consola": "^3.2.3"
       }
     },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -1986,102 +1793,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "highlight": "bin/highlight"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/cli-highlight/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cli-spinners": {
@@ -2107,79 +1818,11 @@
         "node": ">= 12"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -2531,16 +2174,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.24.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
@@ -2554,12 +2187,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2712,15 +2339,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3347,24 +2965,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3419,15 +3019,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -3583,27 +3174,6 @@
         "git-up": "^8.1.0"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3687,15 +3257,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -3767,58 +3328,16 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/human-signals": {
@@ -3828,28 +3347,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3866,42 +3363,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "license": "ISC"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -3922,6 +3388,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4111,15 +3578,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -4196,12 +3654,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "license": "MIT"
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -4536,111 +3988,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/lerna-changelog": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/lerna-changelog/-/lerna-changelog-2.2.0.tgz",
-      "integrity": "sha512-yjYNAHrbnw8xYFKmYWJEP52Tk4xSdlNmzpYr26+3glbSGDmpe8UMo8f9DlEntjGufL+opup421oVTXcLshwAaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "cli-highlight": "^2.1.11",
-        "execa": "^5.0.0",
-        "hosted-git-info": "^4.0.0",
-        "make-fetch-happen": "^9.0.0",
-        "p-map": "^3.0.0",
-        "progress": "^2.0.0",
-        "yargs": "^17.1.0"
-      },
-      "bin": {
-        "lerna-changelog": "bin/cli.js"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/lerna-changelog/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/lerna-changelog/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lerna-changelog/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/lerna-changelog/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lerna-changelog/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/lerna-changelog/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/lerna-changelog/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -5016,15 +4363,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/macos-release": {
@@ -5048,33 +4392,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5132,12 +4449,6 @@
       "engines": {
         "node": ">= 0.10.0"
       }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -5608,15 +4919,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -5634,114 +4936,13 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -5758,17 +4959,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -5796,15 +4986,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/netmask": {
       "version": "2.1.1",
@@ -6119,15 +5300,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -6192,30 +5364,6 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/open": {
       "version": "11.0.0",
@@ -6360,15 +5508,15 @@
       }
     },
     "node_modules/p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -6511,27 +5659,6 @@
         "node": ">=14.13.0"
       }
     },
-    "node_modules/parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "license": "MIT"
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6540,15 +5667,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -6773,34 +5891,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "license": "ISC"
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/protocols": {
@@ -7072,15 +6162,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -7155,31 +6236,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rolldown": {
@@ -7288,7 +6344,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -7490,6 +6546,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -7500,6 +6557,7 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.1.1",
@@ -7508,20 +6566,6 @@
       "engines": {
         "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/source-map": {
@@ -7580,18 +6624,6 @@
       "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -7758,18 +6790,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -7790,18 +6810,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -7845,53 +6853,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -8094,24 +7055,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
       }
     },
     "node_modules/unist-util-stringify-position": {
@@ -8551,12 +7494,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -8572,68 +7509,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "changelog.js",
     "cjs-wrapper.cjs"
   ],
   "scripts": {
@@ -32,9 +33,10 @@
   },
   "dependencies": {
     "execa": "^9.6.1",
-    "lerna-changelog": "^2.2.0",
+    "hosted-git-info": "^9.0.3",
     "lodash": "^4.18.1",
     "mdast-util-from-markdown": "^2.0.3",
+    "p-map": "^7.0.4",
     "tmp": "^0.2.7",
     "validate-peer-dependencies": "^2.2.0",
     "which": "^6.0.1"

--- a/tests/changelog-test.js
+++ b/tests/changelog-test.js
@@ -1,0 +1,211 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, test, expect } from 'vitest';
+import tmp from 'tmp';
+import generateChangelog, {
+  findPullRequestId,
+  renderMarkdown,
+  fetchWithRetry,
+} from '../changelog.js';
+
+tmp.setGracefulCleanup();
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function rootWithRepo(repo = 'https://github.com/foo/bar') {
+  let dir = tmp.dirSync().name;
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ repository: repo }), 'utf8');
+  return dir;
+}
+
+function makeRequest(map) {
+  return async (url) => {
+    if (url in map) return map[url];
+    throw new Error(`unexpected request url: ${url}`);
+  };
+}
+
+describe('findPullRequestId', () => {
+  test('matches squash-merge subjects', () => {
+    expect(findPullRequestId('Add a feature (#123)')).toEqual('123');
+  });
+
+  test('matches "Merge pull request" subjects', () => {
+    expect(findPullRequestId('Merge pull request #45 from foo/bar')).toEqual('45');
+  });
+
+  test('matches homu auto-merge subjects', () => {
+    expect(findPullRequestId('Auto merge of #67 - foo:bar, r=baz')).toEqual('67');
+  });
+
+  test('returns null when there is no PR reference', () => {
+    expect(findPullRequestId('just a plain commit')).toBeNull();
+  });
+});
+
+describe('renderMarkdown', () => {
+  test('rewrites "fixes #N" titles into a Closes link', () => {
+    let releases = [
+      {
+        name: '___unreleased___',
+        date: '2020-03-18',
+        commits: [
+          {
+            categories: [':bug: Bug Fix'],
+            githubIssue: {
+              number: 5,
+              title: 'Fixes #99 in the parser',
+              user: { login: 'alice', html_url: 'https://github.com/alice' },
+              pull_request: { html_url: 'https://github.com/foo/bar/pull/5' },
+            },
+          },
+        ],
+      },
+    ];
+
+    let markdown = renderMarkdown(releases, {
+      categories: [':bug: Bug Fix'],
+      baseIssueUrl: 'https://github.com/foo/bar/issues/',
+      unreleasedName: 'Unreleased',
+    });
+
+    expect(markdown).toEqual(
+      '## Unreleased (2020-03-18)\n\n#### :bug: Bug Fix\n' +
+        '* [#5](https://github.com/foo/bar/pull/5) Closes [#99](https://github.com/foo/bar/issues/99) in the parser ([@alice](https://github.com/alice))'
+    );
+  });
+});
+
+describe('fetchWithRetry', () => {
+  function fakeRes(status, { headers = {}, body = {} } = {}) {
+    return {
+      status,
+      ok: status >= 200 && status < 300,
+      headers: { get: (k) => headers[k.toLowerCase()] ?? null },
+      json: async () => body,
+    };
+  }
+
+  test('retries on 403 then succeeds, honoring Retry-After', async () => {
+    let calls = 0;
+    let slept = [];
+
+    let fetchImpl = async () => {
+      calls += 1;
+      if (calls === 1) return fakeRes(403, { headers: { 'retry-after': '2' } });
+      return fakeRes(200, { body: { ok: true } });
+    };
+
+    let res = await fetchWithRetry(
+      'http://example.test',
+      {},
+      { fetchImpl, sleepImpl: async (ms) => slept.push(ms) }
+    );
+
+    expect(calls).toBe(2);
+    expect(slept).toEqual([2000]);
+    expect(res.status).toBe(200);
+  });
+
+  test('gives up after the configured attempts and returns the last response', async () => {
+    let calls = 0;
+    let fetchImpl = async () => {
+      calls += 1;
+      return fakeRes(403);
+    };
+
+    let res = await fetchWithRetry(
+      'http://example.test',
+      {},
+      { attempts: 3, fetchImpl, sleepImpl: async () => {} }
+    );
+
+    expect(calls).toBe(3);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('generateChangelog', () => {
+  test('produces lerna-changelog-identical markdown for a single release', async () => {
+    let rootPath = rootWithRepo();
+
+    let rawCommits = [
+      { sha: 'aaa', refName: 'HEAD -> master', summary: 'Add a cool feature (#1)', date: today() },
+      { sha: 'bbb', refName: '', summary: 'Fix a bug (#2)', date: today() },
+      { sha: 'ccc', refName: '', summary: 'Bump a dep (#3)', date: today() },
+      { sha: 'ddd', refName: '', summary: 'commit without a PR', date: today() },
+    ];
+
+    let request = makeRequest({
+      'https://api.github.com/repos/foo/bar/issues/1': {
+        number: 1,
+        title: 'Add a cool feature',
+        labels: [{ name: 'enhancement' }],
+        user: { login: 'alice', html_url: 'https://github.com/alice' },
+        pull_request: { html_url: 'https://github.com/foo/bar/pull/1' },
+      },
+      'https://api.github.com/repos/foo/bar/issues/2': {
+        number: 2,
+        title: 'Fix a bug',
+        labels: [{ name: 'bug' }],
+        user: { login: 'bob', html_url: 'https://github.com/bob' },
+        pull_request: { html_url: 'https://github.com/foo/bar/pull/2' },
+      },
+      'https://api.github.com/repos/foo/bar/issues/3': {
+        number: 3,
+        title: 'Bump a dep',
+        labels: [{ name: 'internal' }],
+        // a bot login that is in the default ignore list
+        user: { login: 'dependabot[bot]', html_url: 'https://github.com/apps/dependabot' },
+        pull_request: { html_url: 'https://github.com/foo/bar/pull/3' },
+      },
+      'https://api.github.com/users/alice': {
+        login: 'alice',
+        html_url: 'https://github.com/alice',
+        name: 'Alice A',
+      },
+      'https://api.github.com/users/bob': {
+        login: 'bob',
+        html_url: 'https://github.com/bob',
+        name: null,
+      },
+    });
+
+    let markdown = await generateChangelog({
+      from: 'v1.0.0',
+      rootPath,
+      request,
+      _rawCommits: rawCommits,
+    });
+
+    expect(markdown).toEqual(
+      [
+        `## Unreleased (${today()})`,
+        '',
+        '#### :rocket: Enhancement',
+        '* [#1](https://github.com/foo/bar/pull/1) Add a cool feature ([@alice](https://github.com/alice))',
+        '',
+        '#### :bug: Bug Fix',
+        '* [#2](https://github.com/foo/bar/pull/2) Fix a bug ([@bob](https://github.com/bob))',
+        '',
+        '#### :house: Internal',
+        '* [#3](https://github.com/foo/bar/pull/3) Bump a dep ([@dependabot[bot]](https://github.com/apps/dependabot))',
+        '',
+        // dependabot is excluded from the committers list via ignoreCommitters
+        '#### Committers: 2',
+        '- Alice A ([@alice](https://github.com/alice))',
+        '- [@bob](https://github.com/bob)',
+      ].join('\n')
+    );
+  });
+
+  test('throws when repo cannot be inferred', async () => {
+    let rootPath = tmp.dirSync().name; // no package.json
+
+    await expect(
+      generateChangelog({ from: 'v1.0.0', rootPath, request: makeRequest({}), _rawCommits: [] })
+    ).rejects.toThrow(/Could not infer "repo"/);
+  });
+});

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, test, expect } from 'vitest';
-import { createRequire } from 'module';
 import tmp from 'tmp';
 import { factory, runTasks } from 'release-it/test/util/index.js';
 import Plugin from '../index.js';
@@ -11,9 +10,6 @@ const PATH = process.env.PATH;
 
 tmp.setGracefulCleanup();
 
-const require = createRequire(import.meta.url);
-
-const LERNA_PATH = require.resolve('lerna-changelog/bin/cli');
 const namespace = '@release-it-plugins/lerna-changelog';
 
 function resetPATH() {
@@ -51,13 +47,19 @@ class TestPlugin extends Plugin {
   constructor() {
     super(...arguments);
 
+    // shell command responses (git); the changelog itself is generated
+    // in-process via `_generateChangelog`, stubbed below.
     this.responses = {
       // always assume v1.0.0 unless specifically overridden
       'git describe --tags --abbrev=0': 'v1.0.0',
-
-      [`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`]:
-        '## Unreleased (2020-03-18)\n\nThe changelog',
     };
+
+    // `from` ref -> generated changelog markdown
+    this.changelogResponses = {
+      'v1.0.0': '## Unreleased (2020-03-18)\n\nThe changelog',
+    };
+
+    this.generatedFrom = [];
 
     this.commands = [];
     this.shell.execFormattedCommand = async (command, options) => {
@@ -72,6 +74,12 @@ class TestPlugin extends Plugin {
         }
       }
     };
+  }
+
+  async _generateChangelog(from) {
+    this.generatedFrom.push(from);
+
+    return this.changelogResponses[from];
   }
 
   async _launchEditor(tmpFile) {
@@ -89,18 +97,13 @@ async function buildPlugin(config = {}, _Plugin = TestPlugin) {
 }
 
 describe('@release-it-plugins/lerna-changelog', () => {
-  test('it invokes lerna-changelog', async () => {
+  test('it generates a changelog from the most recent tag', async () => {
     let plugin = await buildPlugin();
 
     await runTasks(plugin);
 
-    expect(plugin.commands).toStrictEqual([
-      ['git describe --tags --abbrev=0', { write: false }],
-      [
-        `${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`,
-        { write: false },
-      ],
-    ]);
+    expect(plugin.commands).toStrictEqual([['git describe --tags --abbrev=0', { write: false }]]);
+    expect(plugin.generatedFrom).toStrictEqual(['v1.0.0']);
   });
 
   test('it honors custom git.tagName formatting', async () => {
@@ -111,13 +114,8 @@ describe('@release-it-plugins/lerna-changelog', () => {
 
     await runTasks(plugin);
 
-    expect(plugin.commands).toStrictEqual([
-      ['git describe --tags --abbrev=0', { write: false }],
-      [
-        `${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`,
-        { write: false },
-      ],
-    ]);
+    expect(plugin.commands).toStrictEqual([['git describe --tags --abbrev=0', { write: false }]]);
+    expect(plugin.generatedFrom).toStrictEqual(['v1.0.0']);
 
     const changelog = fs.readFileSync(infile, { encoding: 'utf8' });
     expect(changelog).toEqual(`## v1.0.1 (2020-03-18)\n\nThe changelog\n\n`);
@@ -133,12 +131,11 @@ describe('@release-it-plugins/lerna-changelog', () => {
     expect(changelog).toEqual('The changelog');
   });
 
-  test('it prints something to CHANGELOG.md when lerna-changelog returns no content', async () => {
+  test('it prints something to CHANGELOG.md when the changelog is empty', async () => {
     let infile = tmp.fileSync().name;
     let plugin = await buildPlugin({ infile });
 
-    plugin.responses[`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`] =
-      '';
+    plugin.changelogResponses['v1.0.0'] = '';
 
     await runTasks(plugin);
 
@@ -158,16 +155,17 @@ describe('@release-it-plugins/lerna-changelog', () => {
         value: 'hahahahaah, does not exist',
       },
       'git rev-list --max-parents=0 HEAD': 'aabc',
-      [`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=aabc`]: `## Unreleased\n\nThe changelog\n## v1.0.0\n\nThe old changelog`,
     });
+    plugin.changelogResponses['aabc'] =
+      `## Unreleased\n\nThe changelog\n## v1.0.0\n\nThe old changelog`;
 
     await runTasks(plugin);
 
     expect(plugin.commands).toStrictEqual([
       ['git describe --tags --abbrev=0', { write: false }],
       ['git rev-list --max-parents=0 HEAD', { write: false }],
-      [`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=aabc`, { write: false }],
     ]);
+    expect(plugin.generatedFrom).toStrictEqual(['aabc']);
 
     const changelog = fs.readFileSync(infile, { encoding: 'utf8' });
     expect(changelog.trim()).toEqual('## v1.0.1\n\nThe changelog\n## v1.0.0\n\nThe old changelog');
@@ -182,21 +180,18 @@ describe('@release-it-plugins/lerna-changelog', () => {
 
     Object.assign(plugin.responses, {
       'git rev-list --max-parents=0 HEAD': 'aabc',
-      [`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=aabc`]: `## Unreleased\n\nThe changelog\n## v1.0.0\n\nThe old changelog`,
     });
+    plugin.changelogResponses['aabc'] =
+      `## Unreleased\n\nThe changelog\n## v1.0.0\n\nThe old changelog`;
 
     await runTasks(plugin);
 
     expect(plugin.commands).toStrictEqual([
       ['git describe --tags --abbrev=0', { write: false }],
-      [
-        `${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`,
-        { write: false },
-      ],
       ['git rev-list --max-parents=0 HEAD', { write: false }],
-      [`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=aabc`, { write: false }],
       [`git add ${infile}`, {}],
     ]);
+    expect(plugin.generatedFrom).toStrictEqual(['v1.0.0', 'aabc']);
 
     const changelog = fs.readFileSync(infile, { encoding: 'utf8' });
     expect(changelog.trim()).toEqual('## v1.0.1\n\nThe changelog\n## v1.0.0\n\nThe old changelog');
@@ -337,13 +332,8 @@ describe('@release-it-plugins/lerna-changelog', () => {
     let errorLogCount = plugin.log.error.mock?.calls.length ?? plugin.log.error.callCount;
     expect(errorLogCount).toBe(0);
 
-    expect(plugin.commands).toStrictEqual([
-      ['git describe --tags --abbrev=0', { write: false }],
-      [
-        `${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`,
-        { write: false },
-      ],
-    ]);
+    expect(plugin.commands).toStrictEqual([['git describe --tags --abbrev=0', { write: false }]]);
+    expect(plugin.generatedFrom).toStrictEqual(['v1.0.0']);
   });
 
   test('formats changelog with prettier when prettier option is true', async () => {
@@ -352,8 +342,7 @@ describe('@release-it-plugins/lerna-changelog', () => {
     plugin.config.setContext({ git: { tagName: 'v${version}' } });
 
     // use * list markers which prettier normalizes to -
-    plugin.responses[`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`] =
-      '## Unreleased (2020-03-18)\n\n* item one\n* item two';
+    plugin.changelogResponses['v1.0.0'] = '## Unreleased (2020-03-18)\n\n* item one\n* item two';
 
     await runTasks(plugin);
 
@@ -366,8 +355,7 @@ describe('@release-it-plugins/lerna-changelog', () => {
     let plugin = await buildPlugin({ infile });
     plugin.config.setContext({ git: { tagName: 'v${version}' } });
 
-    plugin.responses[`${process.execPath} ${LERNA_PATH} --next-version=Unreleased --from=v1.0.0`] =
-      '## Unreleased (2020-03-18)\n\n* item one\n* item two';
+    plugin.changelogResponses['v1.0.0'] = '## Unreleased (2020-03-18)\n\n* item one\n* item two';
 
     await runTasks(plugin);
 


### PR DESCRIPTION
## Summary

lerna-changelog has been unmaintained since 2022 and dragged in ~100 transitive packages, including the deprecated inflight, glob@7, and rimraf@3, purely to make two GitHub API calls. The plugin only ever used it as a black-box CLI returning changelog markdown.

This internalizes that functionality in `changelog.js`:

- List commits in a range via `git log`, extracting PR numbers (squash / merge-commit / homu styles)
- Fetch PR and user data from the GitHub API using native `fetch`, with retry/backoff on 403/429 rate limits
- Group by label into categories and render markdown identical to the previous output
- `p-map` for request concurrency, `hosted-git-info` for repo inference

Intentionally dropped (never used by this plugin): packages/* monorepo grouping, lerna.json config, terminal highlighting, progress bar.

## Dependency impact

| Change | Packages |
| --- | --- |
| Removed lerna-changelog | -101 |
| Added hosted-git-info | +2 |
| Added p-map | +1 |
| Net | -98 |

## Testing

- `npm test` (lint + 26 vitest tests) passes, including new changelog.js unit tests and retry-logic tests
- Real-git smoke test against this repository history produces byte-identical changelog format

Note: output fidelity is verified against the lerna-changelog source and a stubbed GitHub API, not a live authenticated run. A release-it --dry-run with a GITHUB_AUTH token would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)